### PR TITLE
Fix: arch directions

### DIFF
--- a/docs/01-get-started/04-manual.md
+++ b/docs/01-get-started/04-manual.md
@@ -53,7 +53,7 @@ paru -s stardust-xr-protostar
 paru -s stardust-xr-server
 ```
 
-From there, you can launch Stardust with `stardust-xr-telescope`, then in another terminal window or tab, run any other clients you need. We recommend `flatland` and `hexagon-launcher`.
+From there, you can launch Stardust with `telescope`, then in another terminal window or tab, run any other clients you need. We recommend `flatland` and `hexagon-launcher`.
 
 # Manual Build  
 :::caution  


### PR DESCRIPTION
Not sure if the 'then in another terminal window or tab, run any other clients you need. We recommend `flatland` and `hexagon-launcher`.' is also accurate?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the getting started guide to recommend launching Stardust using the `telescope` command instead of `stardust-xr-server`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->